### PR TITLE
updated link for python_io

### DIFF
--- a/research/object_detection/g3doc/using_your_own_dataset.md
+++ b/research/object_detection/g3doc/using_your_own_dataset.md
@@ -3,7 +3,7 @@
 [TOC]
 
 To use your own dataset in Tensorflow Object Detection API, you must convert it
-into the [TFRecord file format](https://www.tensorflow.org/api_guides/python/python_io#tfrecords_format_details).
+into the [TFRecord file format](https://www.tensorflow.org/api_docs/python/tf/python_io).
 This document outlines how to write a script to generate the TFRecord file.
 
 ## Label Maps


### PR DESCRIPTION
The link https://www.tensorflow.org/api_guides/python/python_io#tfrecords_format_details is 404. Instead updated link to: https://www.tensorflow.org/api_docs/python/tf/python_io